### PR TITLE
workers: Take build deps from the Jessie backports

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -107,7 +107,7 @@ from buildbot.status import html, web
 authz_cfg = web.authz.Authz(
     auth=web.auth.BasicAuth([('$admin_login', '$admin_password')]), forceBuild='auth',
     forceAllBuilds='auth', gracefulShutdown=False, pingBuilder=False,
-    stopBuild=False, stopAllBuilds=False, cancelPendingBuild=False)
+    stopBuild=True, stopAllBuilds=False, cancelPendingBuild=False)
 
 c['status'] = [
     html.WebStatus(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -68,11 +68,15 @@ amd64_pkg_factory.addStep(steps.Git(
     repourl='https://github.com/ideascube/ideascube.git',
     mode='incremental', branch='master'))
 amd64_pkg_factory.addStep(steps.ShellCommand(
-    command=['sudo', 'sbuild-update', '-udcar', 'jessie-amd64-sbuild']))
+    command=[
+        'sudo', 'sbuild-update', '--update', '--dist-upgrade', '--clean',
+        '--autoclean', '--autoremove', 'jessie-amd64-sbuild',
+        ]))
 amd64_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('amd64'), timeout=2400,
     command=[
-        'sbuild', '-s', '--dist=jessie', '--arch=amd64', '--build-dep-resolver=aptitude',
+        'sbuild', '--source', '--dist=jessie', '--arch=amd64',
+        '--build-dep-resolver=aptitude',
         '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
         ]))
 amd64_pkg_factory.addStep(steps.ShellCommand(
@@ -83,11 +87,15 @@ armhf_pkg_factory.addStep(steps.Git(
     repourl='https://github.com/ideascube/ideascube.git',
     mode='incremental', branch='master'))
 armhf_pkg_factory.addStep(steps.ShellCommand(
-    command=['sudo', 'sbuild-update', '-udcar', 'jessie-armhf-sbuild']))
+    command=[
+        'sudo', 'sbuild-update', '--update', '--dist-upgrade', '--clean',
+        '--autoclean', '--autoremove', 'jessie-armhf-sbuild',
+        ]))
 armhf_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('armhf'), timeout=2400,
     command=[
-        'sbuild', '-s', '--dist=jessie', '--arch=armhf', '--build-dep-resolver=aptitude',
+        'sbuild', '--source', '--dist=jessie', '--arch=armhf',
+        '--build-dep-resolver=aptitude',
         '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
         ]))
 armhf_pkg_factory.addStep(steps.ShellCommand(

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -71,7 +71,9 @@ amd64_pkg_factory.addStep(steps.ShellCommand(
     command=['sudo', 'sbuild-update', '-udcar', 'jessie-amd64-sbuild']))
 amd64_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('amd64'), timeout=2400,
-    command=['sbuild', '-s', '-d', 'jessie', '--arch', 'amd64']))
+    command=[
+        'sbuild', '-s', '--dist=jessie', '--arch=amd64',
+        ]))
 amd64_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'local', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))
 
@@ -83,7 +85,9 @@ armhf_pkg_factory.addStep(steps.ShellCommand(
     command=['sudo', 'sbuild-update', '-udcar', 'jessie-armhf-sbuild']))
 armhf_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('armhf'), timeout=2400,
-    command=['sbuild', '-s', '-d', 'jessie', '--arch', 'armhf']))
+    command=[
+        'sbuild', '-s', '--dist=jessie', '--arch=armhf',
+        ]))
 armhf_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'remote', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -72,7 +72,8 @@ amd64_pkg_factory.addStep(steps.ShellCommand(
 amd64_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('amd64'), timeout=2400,
     command=[
-        'sbuild', '-s', '--dist=jessie', '--arch=amd64',
+        'sbuild', '-s', '--dist=jessie', '--arch=amd64', '--build-dep-resolver=aptitude',
+        '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
         ]))
 amd64_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'local', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))
@@ -86,7 +87,8 @@ armhf_pkg_factory.addStep(steps.ShellCommand(
 armhf_pkg_factory.addStep(steps.SetPropertyFromCommand(
     extract_fn=get_changes_file('armhf'), timeout=2400,
     command=[
-        'sbuild', '-s', '--dist=jessie', '--arch=armhf',
+        'sbuild', '-s', '--dist=jessie', '--arch=armhf', '--build-dep-resolver=aptitude',
+        '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
         ]))
 armhf_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'remote', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))


### PR DESCRIPTION
The `--extra-repository` will add the Jessie backports as a valid archive to use in the chroot.

But unfortunately, that's not enough because the `Release` file for the backports archive has `"NotAutomatic: yes"`. As a result, even though the backports contain the dependency we need, it doesn't get taken from there automatically.

That's where the `--build-dep-resolver=aptitude` comes into play: aptitude also stumbles on the missing dependency like apt, but then it finds it in the backports archive and automatically decides to take it (and only it) from there.

http://unix.stackexchange.com/a/298116/178537

Fixes #8
