### PR TITLE
properly call the sbuild command

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -77,7 +77,7 @@ amd64_pkg_factory.addStep(steps.SetPropertyFromCommand(
     command=[
         'sbuild', '--source', '--dist=jessie', '--arch=amd64',
         '--build-dep-resolver=aptitude',
-        '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
+        '--extra-repository=deb http://ftp.fr.debian.org/debian jessie-backports main',
         ]))
 amd64_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'local', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))
@@ -96,7 +96,7 @@ armhf_pkg_factory.addStep(steps.SetPropertyFromCommand(
     command=[
         'sbuild', '--source', '--dist=jessie', '--arch=armhf',
         '--build-dep-resolver=aptitude',
-        '--extra-repository="deb http://ftp.fr.debian.org/debian jessie-backports main"',
+        '--extra-repository=deb http://ftp.fr.debian.org/debian jessie-backports main',
         ]))
 armhf_pkg_factory.addStep(steps.ShellCommand(
     command=['dput', 'remote', util.Interpolate('%(prop:workdir)s/%(prop:changes_file)s')]))


### PR DESCRIPTION
Turns out that was one too many level of quotes, and sbuild was failing badly.
