### PR TITLE
Run lintian after builds

### DIFF
--- a/debian/dot_sbuildrc
+++ b/debian/dot_sbuildrc
@@ -1,0 +1,3 @@
+# Run lintian for quality check
+$run_lintian = 1;
+$lintian_opts = ['-i', '-I'];

--- a/docs/debian-packaging.md
+++ b/docs/debian-packaging.md
@@ -70,6 +70,11 @@ If the `sbuild` command finished successfully, you'll find an
 tree. You can remove the git tree as well as the build artefacts, they are not
 necessary any more.
 
+One last thing to do is add some local `sbuild` configuration.
+
+To do so, install the `debian/dot_sbuildrc` file provided in this repository,
+as `~/.sbuildrc` in the `buildbot` user's home.
+
 ### Configuring dput
 
 Once packages are built on the worker, we need to upload them to the master


### PR DESCRIPTION
This tells sbuild to run lintian when a build otherwise succeeded.

Lintian will report on various quality checks of the packaging, which should ultimately help us improve.

The build won't fail if lintian finds issues, though, it is purely advisory. (for now?)

Fixes #9
