### PR TITLE
Tell sbuild to be verbose

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -54,7 +54,7 @@ pkg_factory.addStep(steps.ShellCommand(
         util.Interpolate('jessie-%(prop:arch)s-sbuild'),
         ]))
 pkg_factory.addStep(steps.ShellCommand(
-    timeout=3600, command=[
+    command=[
         'sbuild', '--verbose', '--source', '--dist=jessie',
         util.Interpolate('--arch=%(prop:arch)s'),
         '--build-dep-resolver=aptitude',

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -55,7 +55,7 @@ pkg_factory.addStep(steps.ShellCommand(
         ]))
 pkg_factory.addStep(steps.ShellCommand(
     timeout=3600, command=[
-        'sbuild', '--source', '--dist=jessie',
+        'sbuild', '--verbose', '--source', '--dist=jessie',
         util.Interpolate('--arch=%(prop:arch)s'),
         '--build-dep-resolver=aptitude',
         '--extra-repository=deb http://ftp.fr.debian.org/debian jessie-backports main',


### PR DESCRIPTION
This brings two benefits:

* we can finally see the sbuild output in the web interface;
* tasks should not time out any more;